### PR TITLE
reordered chapters, hiding some of them

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The repository is divided in sevaral branches which represent the different chap
 - The :computer: / `code` branches provide code for exploring the programmatic strategies.
 
 Educational trail:
-1. ( :book: ) [The two generals](https://github.com/in-der-kothe/exactly-once-semantics/tree/theory/two-generals)
-2. ( :book: ) [Exactly one delivery](https://github.com/in-der-kothe/exactly-once-semantics/tree/theory/exactly-once-delivery)
-3. ( :computer: ) [Naive payment system](https://github.com/in-der-kothe/exactly-once-semantics/tree/code/naive-payment-system)
-4. ( :computer: ) [Payment system with retry](https://github.com/in-der-kothe/exactly-once-semantics/tree/code/payment-system-with-retry)
-5. ( :book: ) [The eight fallacies](https://github.com/in-der-kothe/exactly-once-semantics/tree/theory/fallacies)
+1. ( :book: ) [The eight fallacies](https://github.com/in-der-kothe/exactly-once-semantics/tree/theory/fallacies)
+3. ( :book: ) [Exactly once delivery](https://github.com/in-der-kothe/exactly-once-semantics/tree/theory/exactly-once-delivery)
+2. ( :book: ) [The two generals](https://github.com/in-der-kothe/exactly-once-semantics/tree/theory/two-generals)
+4. ( :computer: ) [A naive payment system](https://github.com/in-der-kothe/exactly-once-semantics/tree/code/naive-payment-system)
+5. ( :computer: ) [A Payment system with retries](https://github.com/in-der-kothe/exactly-once-semantics/tree/code/payment-system-with-retry)


### PR DESCRIPTION
Hey,
ich würde glaube, das wir erst was zu den acht problemen sagen, halt um zu zeigen, dass ist ein bekanntes problem und ein üblicher _fehler_ zu denke dass es die nicht gibt.

Bei dem nächsten Kapitel bin ich mir nicht sicher wo es sinvoll hingehört. Wenn es vor dem two general problem liegt, verrät es schon die "lösung" und verwirrt vermutlich trotzdem. 
wenn wir es danach machen, dann wohl eher ganz zum schluss. ob es dann noch für jemanden nützlich ist, weiß ich nicht ;-)

ich hab nur das erste kapitel des code teils hier angeteasert um nicht schon die anderen lösungen vorweg zumehmen.
Also wen man schon hier retry liest und idempotence, dann ist die frage später: wie könnte man das besser machen komisch.
Es gibt zwar noch die Branchnahmen.( wobei vielleicht sollten wir die weniger verräterisch machen), aber das fällt den anderen wohl eher weniger auf.

(und es heißt exactly _once_ del. und nicht one ) :-)
